### PR TITLE
feat: OAuth authentication

### DIFF
--- a/allure-jira-commons/src/main/java/io/qameta/allure/jira/JiraServiceBuilder.java
+++ b/allure-jira-commons/src/main/java/io/qameta/allure/jira/JiraServiceBuilder.java
@@ -78,8 +78,8 @@ public class JiraServiceBuilder {
     }
 
     public JiraServiceBuilder defaults() {
-        String clientIdEnv = getProperty(ALLURE_JIRA_CLIENT_ID).orElse(null);
-        String clientSecretEnv = getProperty(ALLURE_JIRA_CLIENT_SECRET).orElse(null);
+        final String clientIdEnv = getProperty(ALLURE_JIRA_CLIENT_ID).orElse(null);
+        final String clientSecretEnv = getProperty(ALLURE_JIRA_CLIENT_SECRET).orElse(null);
         if (clientIdEnv != null && clientSecretEnv != null) {
             clientId(clientId);
             clientSecret(clientSecret);

--- a/allure-jira-commons/src/main/java/io/qameta/allure/jira/retrofit/OAuthInterceptor.java
+++ b/allure-jira-commons/src/main/java/io/qameta/allure/jira/retrofit/OAuthInterceptor.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jira.retrofit;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * Basic authenticator for okhttp client.
+ */
+public final class OAuthInterceptor implements Interceptor {
+
+    private final String credentials;
+
+    public OAuthInterceptor(final String clientId, final String clientSecret) {
+        this.credentials = "{ \"client_id\": \"" + clientId + "\", \"client_secret\": \"" + clientSecret
+                + "\" }";
+    }
+
+    @Override
+    public Response intercept(final Chain chain) throws IOException {
+        final Request request = chain.request();
+        final Request authenticatedRequest = request.newBuilder()
+                .header("Authorization", credentials).build();
+        return chain.proceed(authenticatedRequest);
+    }
+
+}

--- a/plugins/jira-plugin/src/main/java/io/qameta/allure/jira/JiraExportPlugin.java
+++ b/plugins/jira-plugin/src/main/java/io/qameta/allure/jira/JiraExportPlugin.java
@@ -53,7 +53,11 @@ public class JiraExportPlugin implements Aggregator2 {
         this(
                 getProperty(ALLURE_JIRA_ENABLED).map(Boolean::parseBoolean).orElse(false),
                 getProperty(ALLURE_JIRA_LAUNCH_ISSUES).orElse(""),
-                () -> new JiraServiceBuilder().defaults().build()
+                () -> new JiraServiceBuilder()
+                        .defaults()
+                        .clientId("")
+                        .clientSecret("")
+                        .build()
         );
     }
 
@@ -83,11 +87,9 @@ public class JiraExportPlugin implements Aggregator2 {
                     .map(testResult -> JiraExportUtils.getJiraTestResult(executor, testResult))
                     .filter(Optional::isPresent)
                     .map(Optional::get)
-                    .forEach(jiraTestResult -> {
-                        JiraExportUtils.getTestResults(launchesResults)
-                                .forEach(testResult ->
-                                        exportTestResultToJira(jiraService, jiraTestResult, testResult));
-                    });
+                    .forEach(jiraTestResult -> JiraExportUtils.getTestResults(launchesResults)
+                            .forEach(testResult ->
+                                    exportTestResultToJira(jiraService, jiraTestResult, testResult)));
         }
     }
 
@@ -103,8 +105,7 @@ public class JiraExportPlugin implements Aggregator2 {
             if (!failedExports.isEmpty()) {
                 logErrorResults(failedExports);
             } else {
-                LOGGER.info(String.format("Allure launch '%s' synced with issues  successfully%n",
-                        issues));
+                LOGGER.info(String.format("Allure launch '%s' synced with issues  successfully%n", issues));
                 LOGGER.info(String.format("Results of launch export %n %s", created));
             }
 


### PR DESCRIPTION
Add OAuth authentication method for Allure2 report

### Context
Currently, basic authentication is supported by it was deprecated for Jira cloud. This PR implements authentication with `clientid` and `secretid` parameters.

#### Checklist
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
